### PR TITLE
Modify browser field for bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "4.1.6",
   "description": "Eval embedded value in json. Useful to define message resource object.",
   "main": "shim/node",
-  "browser": "shim/browser",
+  "browser": {
+    "shim/node": "./shim/browser",
+    "child_process": false
+  },
   "scripts": {
     "test": "node ./ci/test.js",
     "prepare": "node ./ci/build.js && node ./ci/shim.js"


### PR DESCRIPTION
Webpackでバンドルする際に `Module not found: Error: Can't resolve 'child_process'` という警告が出る。
これはバンドルする際にすべての require を先に読み込むためなので、 child_process を無視するように Webpack に教える必要がある。

package.json の browser フィールドに指定すると、バンドラー（webpackもbrowserifyも）がきちんと無視してくれるようなので、書きました。

参考
http://qiita.com/shinout/items/4c9854b00977883e0668